### PR TITLE
feat: async unlock with visual feedback and per-entity request locking

### DIFF
--- a/ha.go
+++ b/ha.go
@@ -149,7 +149,7 @@ func DomainService(entityID string) (domain, service string) {
 	prefix, _, _ := strings.Cut(entityID, ".")
 	switch prefix {
 	case "lock":
-		return "lock", "unlock"
+		return "lock", "open"
 	case "cover":
 		return "cover", "open_cover"
 	case "button":

--- a/ha_test.go
+++ b/ha_test.go
@@ -14,7 +14,7 @@ func TestDomainService(t *testing.T) {
 		wantDomain      string
 		wantService     string
 	}{
-		{"lock.front_door", "lock", "unlock"},
+		{"lock.front_door", "lock", "open"},
 		{"cover.garage", "cover", "open_cover"},
 		{"button.doorbell", "button", "press"},
 		{"script.open_gate", "script", "turn_on"},

--- a/handlers.go
+++ b/handlers.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -19,11 +20,13 @@ type DoorConfig struct {
 }
 
 type App struct {
-	Config      *Config
-	HAClient    *HAClient
-	RateLimiter *RateLimiter
-	Templates   *template.Template
-	Doors       []DoorConfig
+	Config       *Config
+	HAClient     *HAClient
+	RateLimiter  *RateLimiter
+	Templates    *template.Template
+	Doors        []DoorConfig
+	inProgress   map[string]bool
+	inProgressMu sync.Mutex
 }
 
 func requestCtx(r *http.Request) (context.Context, context.CancelFunc) {
@@ -119,7 +122,6 @@ func (a *App) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 type dashboardData struct {
-	Success         string
 	Doors           []DoorConfig
 	HomeKeysEnabled bool
 }
@@ -143,11 +145,6 @@ func (a *App) DashboardHandler(w http.ResponseWriter, r *http.Request) {
 	data := dashboardData{
 		Doors:           a.Doors,
 		HomeKeysEnabled: homeKeysEnabled == "on",
-	}
-	if key := r.URL.Query().Get("success"); key != "" {
-		if d := a.findDoor(key); d != nil {
-			data.Success = d.Name
-		}
 	}
 
 	if err := a.Templates.ExecuteTemplate(w, "dashboard.html", data); err != nil {
@@ -185,6 +182,23 @@ func (a *App) OpenDoorHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	a.inProgressMu.Lock()
+	if a.inProgress[door.EntityID] {
+		a.inProgressMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]string{"error": "unlock already in progress"}) //nolint:errcheck
+		return
+	}
+	a.inProgress[door.EntityID] = true
+	a.inProgressMu.Unlock()
+
+	defer func() {
+		a.inProgressMu.Lock()
+		delete(a.inProgress, door.EntityID)
+		a.inProgressMu.Unlock()
+	}()
+
 	domain, service := DomainService(door.EntityID)
 	if err := a.HAClient.CallService(ctx, domain, service, door.EntityID); err != nil {
 		log.Printf("[DOOR_ERROR] ip=%s action=%s error=%v", ip, door.Name, err)
@@ -193,7 +207,8 @@ func (a *App) OpenDoorHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("[DOOR] ip=%s action=%s", ip, door.Name)
-	http.Redirect(w, r, "/?success="+door.Key, http.StatusSeeOther)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"ok": true, "name": door.Name}) //nolint:errcheck
 }
 
 func (a *App) entityIDs() []string {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -7,14 +7,16 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
-// fakeHA builds a test HA server. The handler map is keyed by entity ID path suffix.
-// If a key is missing the server returns 500.
+// Missing entity IDs return 500, matching real HA behaviour for unknown entities.
 type fakeHAConfig struct {
-	states   map[string]string // entity_id → state
-	failOpen bool              // make CallService return 500
+	states    map[string]string // entity_id → state
+	failOpen  bool              // make CallService return 500
+	openDelay time.Duration     // artificial delay for CallService
 }
 
 func newFakeHA(cfg fakeHAConfig) *httptest.Server {
@@ -34,6 +36,9 @@ func newFakeHA(cfg fakeHAConfig) *httptest.Server {
 				http.Error(w, "error", http.StatusInternalServerError)
 				return
 			}
+			if cfg.openDelay > 0 {
+				time.Sleep(cfg.openDelay)
+			}
 			w.WriteHeader(http.StatusOK)
 			return
 		}
@@ -46,14 +51,15 @@ func newTestApp(t *testing.T, ha *httptest.Server, doors []DoorConfig, unlockAll
 	tmpl := template.Must(template.ParseFS(templateFS, "templates/*.html"))
 	return &App{
 		Config: &Config{
-			SessionSecret:        []byte("test-secret-at-least-16-chars!!"),
+			SessionSecret:         []byte("test-secret-at-least-16-chars!!"),
 			EntityUnlockAllowance: unlockAllowance,
-			EntityDoorCode:       doorCode,
+			EntityDoorCode:        doorCode,
 		},
 		HAClient:    NewHAClient(ha.URL, "token"),
 		RateLimiter: newRateLimiter(),
 		Templates:   tmpl,
 		Doors:       doors,
+		inProgress:  make(map[string]bool),
 	}
 }
 
@@ -196,10 +202,88 @@ func TestOpenDoorHandler_Success(t *testing.T) {
 	w := httptest.NewRecorder()
 	app.OpenDoorHandler(w, r)
 
-	if w.Code != http.StatusSeeOther {
-		t.Errorf("success should redirect, got %d", w.Code)
+	if w.Code != http.StatusOK {
+		t.Errorf("success should return 200, got %d", w.Code)
 	}
-	if loc := w.Header().Get("Location"); !strings.Contains(loc, "success=lock_front") {
-		t.Errorf("redirect location missing success param: %s", loc)
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	if body := w.Body.String(); !strings.Contains(body, `"ok":true`) {
+		t.Errorf("response body missing ok:true: %s", body)
+	}
+}
+
+func TestOpenDoorHandler_ConcurrentRequestRejected(t *testing.T) {
+	ha := newFakeHA(fakeHAConfig{
+		states: map[string]string{
+			"input_boolean.allowance": "on",
+			"lock.front":              "locked",
+		},
+		openDelay: 100 * time.Millisecond,
+	})
+	defer ha.Close()
+
+	doors := []DoorConfig{{Key: "lock_front", Name: "Front", EntityID: "lock.front"}}
+	app := newTestApp(t, ha, doors, "input_boolean.allowance", "input_text.code")
+
+	type result struct{ code int }
+	results := make(chan result, 2)
+
+	var ready sync.WaitGroup
+	ready.Add(2)
+	var start sync.WaitGroup
+	start.Add(1)
+
+	for range 2 {
+		go func() {
+			form := url.Values{"door": {"lock_front"}}
+			r := httptest.NewRequest(http.MethodPost, "/open", strings.NewReader(form.Encode()))
+			r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			r.RemoteAddr = "127.0.0.1:1234"
+			w := httptest.NewRecorder()
+			ready.Done()
+			start.Wait()
+			app.OpenDoorHandler(w, r)
+			results <- result{w.Code}
+		}()
+	}
+	ready.Wait()
+	start.Done()
+
+	codes := []int{(<-results).code, (<-results).code}
+	okCount, conflictCount := 0, 0
+	for _, c := range codes {
+		switch c {
+		case http.StatusOK:
+			okCount++
+		case http.StatusConflict:
+			conflictCount++
+		}
+	}
+	if okCount != 1 || conflictCount != 1 {
+		t.Errorf("expected 1×200 and 1×409, got codes %v", codes)
+	}
+}
+
+func TestOpenDoorHandler_LockReleasedAfterCompletion(t *testing.T) {
+	ha := newFakeHA(fakeHAConfig{states: map[string]string{
+		"input_boolean.allowance": "on",
+		"lock.front":              "locked",
+	}})
+	defer ha.Close()
+
+	doors := []DoorConfig{{Key: "lock_front", Name: "Front", EntityID: "lock.front"}}
+	app := newTestApp(t, ha, doors, "input_boolean.allowance", "input_text.code")
+
+	for i := range 2 {
+		form := url.Values{"door": {"lock_front"}}
+		r := httptest.NewRequest(http.MethodPost, "/open", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.RemoteAddr = "127.0.0.1:1234"
+		w := httptest.NewRecorder()
+		app.OpenDoorHandler(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("request %d: expected 200, got %d", i+1, w.Code)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -124,6 +124,7 @@ func main() {
 		RateLimiter: rl,
 		Templates:   tmpl,
 		Doors:       doors,
+		inProgress:  make(map[string]bool),
 	}
 
 	startupCtx, startupCancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -19,22 +19,21 @@
   </div>
   {{else}}
 
-  {{if .Success}}
-  <p class="text-green-700 bg-green-50 border border-green-200 rounded-lg px-4 py-2 font-medium">
-    ✓ {{.Success}} has been opened.
-  </p>
-  {{end}}
+  <div id="status-banner" role="status" class="hidden"></div>
 
   {{range .Doors}}
-  <form method="POST" action="/open">
-    <input type="hidden" name="door" value="{{.Key}}">
-    <button
-      type="submit"
-      class="w-72 h-24 text-xl font-semibold bg-green-500 hover:bg-green-600 active:scale-95 text-white rounded-2xl shadow-lg transition select-none"
-    >
-      Open {{.Name}}
-    </button>
-  </form>
+  <button
+    data-key="{{.Key}}"
+    data-name="{{.Name}}"
+    onclick="openDoor(this)"
+    class="w-72 h-24 text-xl font-semibold bg-green-500 hover:bg-green-600 active:scale-95 text-white rounded-2xl shadow-lg transition select-none flex items-center justify-center gap-3 disabled:opacity-60 disabled:cursor-not-allowed disabled:active:scale-100"
+  >
+    <span class="btn-label">Open {{.Name}}</span>
+    <svg class="btn-spinner hidden animate-spin h-6 w-6 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+    </svg>
+  </button>
   {{end}}
 
   {{end}}
@@ -44,5 +43,59 @@
       Logout
     </button>
   </form>
+
+  <script>
+    async function openDoor(btn) {
+      if (btn.disabled) return;
+      const key    = btn.dataset.key;
+      const name   = btn.dataset.name;
+      const label  = btn.querySelector('.btn-label');
+      const spinner = btn.querySelector('.btn-spinner');
+
+      btn.disabled = true;
+      label.textContent = 'Opening…';
+      spinner.classList.remove('hidden');
+      hideBanner();
+
+      try {
+        const res = await fetch('/open', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+          body: 'door=' + encodeURIComponent(key)
+        });
+
+        if (res.ok) {
+          showBanner('success', '✓ ' + name + ' has been opened.');
+        } else if (res.status === 409) {
+          showBanner('warn', 'Already opening — please wait.');
+        } else if (res.status === 403) {
+          showBanner('error', 'Door openers are currently not active.');
+        } else {
+          showBanner('error', 'Could not open ' + name + '.');
+        }
+      } catch (_) {
+        showBanner('error', 'Network error — check your connection.');
+      } finally {
+        btn.disabled = false;
+        label.textContent = 'Open ' + name;
+        spinner.classList.add('hidden');
+      }
+    }
+
+    function showBanner(type, msg) {
+      var el = document.getElementById('status-banner');
+      var styles = {
+        success: 'w-full max-w-sm rounded-lg px-4 py-3 text-sm font-medium text-center bg-green-50 border border-green-200 text-green-700',
+        warn:    'w-full max-w-sm rounded-lg px-4 py-3 text-sm font-medium text-center bg-yellow-50 border border-yellow-200 text-yellow-800',
+        error:   'w-full max-w-sm rounded-lg px-4 py-3 text-sm font-medium text-center bg-red-50 border border-red-200 text-red-700'
+      };
+      el.className = styles[type] || styles.error;
+      el.textContent = msg;
+    }
+
+    function hideBanner() {
+      document.getElementById('status-banner').className = 'hidden';
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
- Replace form POST redirect with fetch() so the page never reloads; buttons show a spinner and "Opening…" label while the HA call is in flight and an inline status banner reports success/warn/error
- Add per-entity in-progress lock in OpenDoorHandler (sync.Mutex + map[string]bool) so at most one unlock per entity is in flight; concurrent duplicates receive 409 Conflict with a JSON error body
- OpenDoorHandler now returns JSON ({"ok":true,"name":"..."} or {"error":"..."}) consistent with HealthHandler's json.NewEncoder usage
- Change lock domain service from lock.unlock to lock.open
- Tests: update success assertion to 200 JSON, add TestOpenDoorHandler_ConcurrentRequestRejected (WaitGroup barrier) and TestOpenDoorHandler_LockReleasedAfterCompletion